### PR TITLE
feat: per-app debounce toggles (FEAT-006)

### DIFF
--- a/app/src/main/java/com/vibedebounce/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/vibedebounce/prefs/AppPrefs.kt
@@ -13,7 +13,7 @@ class AppPrefs(context: Context) {
     private val sharedPrefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
 
     fun getSeenPackages(): Set<String> =
-        sharedPrefs.getStringSet(KEY_SEEN_PACKAGES, emptySet()) ?: emptySet()
+        sharedPrefs.getStringSet(KEY_SEEN_PACKAGES, emptySet())?.toSet() ?: emptySet()
 
     fun addSeenPackage(packageName: String) {
         val current = getSeenPackages().toMutableSet()

--- a/app/src/main/java/com/vibedebounce/prefs/AppPrefs.kt
+++ b/app/src/main/java/com/vibedebounce/prefs/AppPrefs.kt
@@ -1,0 +1,31 @@
+package com.vibedebounce.prefs
+
+import android.content.Context
+
+class AppPrefs(context: Context) {
+
+    companion object {
+        private const val PREFS_FILE = "app_prefs"
+        private const val KEY_SEEN_PACKAGES = "seen_packages"
+        private const val KEY_PREFIX_ENABLED = "enabled_"
+    }
+
+    private val sharedPrefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+
+    fun getSeenPackages(): Set<String> =
+        sharedPrefs.getStringSet(KEY_SEEN_PACKAGES, emptySet()) ?: emptySet()
+
+    fun addSeenPackage(packageName: String) {
+        val current = getSeenPackages().toMutableSet()
+        if (current.add(packageName)) {
+            sharedPrefs.edit().putStringSet(KEY_SEEN_PACKAGES, current).apply()
+        }
+    }
+
+    fun isAppEnabled(packageName: String): Boolean =
+        sharedPrefs.getBoolean(KEY_PREFIX_ENABLED + packageName, true)
+
+    fun setAppEnabled(packageName: String, enabled: Boolean) {
+        sharedPrefs.edit().putBoolean(KEY_PREFIX_ENABLED + packageName, enabled).apply()
+    }
+}

--- a/app/src/main/java/com/vibedebounce/service/DebounceNotificationService.kt
+++ b/app/src/main/java/com/vibedebounce/service/DebounceNotificationService.kt
@@ -11,6 +11,7 @@ import android.service.notification.StatusBarNotification
 import androidx.annotation.VisibleForTesting
 import com.vibedebounce.model.DebounceTimer
 import com.vibedebounce.model.SenderKey
+import com.vibedebounce.prefs.AppPrefs
 import com.vibedebounce.prefs.DebouncePrefs
 
 class DebounceNotificationService : NotificationListenerService() {
@@ -35,6 +36,7 @@ class DebounceNotificationService : NotificationListenerService() {
     private lateinit var ringerStateManager: RingerStateManager
     private lateinit var notifier: NewThreadNotifier
     private lateinit var debouncePrefs: DebouncePrefs
+    private lateinit var appPrefs: AppPrefs
     private lateinit var foregroundNotificationManager: ForegroundNotificationManager
     private val activeTimers = mutableMapOf<SenderKey, DebounceTimer>()
     @VisibleForTesting
@@ -51,6 +53,7 @@ class DebounceNotificationService : NotificationListenerService() {
         val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
         ringerStateManager = RingerStateManager(audioManager)
         debouncePrefs = DebouncePrefs(this)
+        appPrefs = AppPrefs(this)
         debounceWindowMs = debouncePrefs.debounceWindowSeconds * 1000L
         debouncePrefs.registerOnChangeListener(prefsListener)
 
@@ -76,6 +79,9 @@ class DebounceNotificationService : NotificationListenerService() {
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification) {
+        recordSeenApp(sbn.packageName)
+        if (!shouldDebounce(sbn.packageName)) return
+
         val extras = sbn.notification.extras
         val title = extras.getString(Notification.EXTRA_TITLE) ?: return
         val key = SenderKey(sbn.packageName, title)
@@ -115,6 +121,16 @@ class DebounceNotificationService : NotificationListenerService() {
             ForegroundNotificationManager.NOTIFICATION_ID,
             foregroundNotificationManager.buildNotification(activeTimers.size)
         )
+    }
+
+    @VisibleForTesting
+    internal fun recordSeenApp(packageName: String) {
+        appPrefs.addSeenPackage(packageName)
+    }
+
+    @VisibleForTesting
+    internal fun shouldDebounce(packageName: String): Boolean {
+        return appPrefs.isAppEnabled(packageName)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/vibedebounce/ui/AppListAdapter.kt
+++ b/app/src/main/java/com/vibedebounce/ui/AppListAdapter.kt
@@ -1,0 +1,55 @@
+package com.vibedebounce.ui
+
+import android.graphics.drawable.Drawable
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.vibedebounce.databinding.ItemAppToggleBinding
+
+data class AppItem(
+    val packageName: String,
+    val label: String,
+    val icon: Drawable?,
+    val enabled: Boolean
+)
+
+class AppListAdapter(
+    private val onToggle: (packageName: String, enabled: Boolean) -> Unit
+) : RecyclerView.Adapter<AppListAdapter.ViewHolder>() {
+
+    private val items = mutableListOf<AppItem>()
+
+    fun submitList(newItems: List<AppItem>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemAppToggleBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    inner class ViewHolder(
+        private val binding: ItemAppToggleBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: AppItem) {
+            binding.appName.text = item.label
+            binding.appIcon.setImageDrawable(item.icon)
+            binding.appToggle.setOnCheckedChangeListener(null)
+            binding.appToggle.isChecked = item.enabled
+            binding.appToggle.setOnCheckedChangeListener { _, isChecked ->
+                onToggle(item.packageName, isChecked)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vibedebounce/ui/MainActivity.kt
+++ b/app/src/main/java/com/vibedebounce/ui/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.vibedebounce.ui
 
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Typeface
 import android.os.Bundle
 import android.provider.Settings
@@ -9,16 +10,20 @@ import android.widget.LinearLayout
 import android.widget.SeekBar
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.vibedebounce.databinding.ActivityMainBinding
+import com.vibedebounce.prefs.AppPrefs
 import com.vibedebounce.prefs.DebouncePrefs
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
     private lateinit var debouncePrefs: DebouncePrefs
+    private lateinit var appPrefs: AppPrefs
     private lateinit var permissionChecker: PermissionChecker
     private lateinit var permissionGuard: PermissionGuard
     private lateinit var serviceStatusProvider: ServiceStatusProviderContract
+    private lateinit var appListAdapter: AppListAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,18 +31,21 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         debouncePrefs = DebouncePrefs(this)
+        appPrefs = AppPrefs(this)
         permissionChecker = PermissionChecker(this)
         permissionGuard = PermissionGuard(permissionChecker)
         serviceStatusProvider = ServiceStatusProvider()
 
         setupDebounceSlider()
         setupPermissionButtons()
+        setupAppList()
     }
 
     override fun onResume() {
         super.onResume()
         updatePermissionStatus()
         updateServiceStatus()
+        populateAppList()
     }
 
     private fun updateServiceStatus() {
@@ -95,6 +103,42 @@ class MainActivity : AppCompatActivity() {
         binding.statusDndAccess.text = if (dndAccessGranted) "Granted" else "Not granted"
         binding.btnNotificationAccess.isEnabled = !notificationAccessGranted
         binding.btnDndAccess.isEnabled = !dndAccessGranted
+    }
+
+    private fun setupAppList() {
+        appListAdapter = AppListAdapter { packageName, enabled ->
+            appPrefs.setAppEnabled(packageName, enabled)
+        }
+        binding.appList.layoutManager = LinearLayoutManager(this)
+        binding.appList.adapter = appListAdapter
+    }
+
+    private fun populateAppList() {
+        val seenPackages = appPrefs.getSeenPackages().sorted()
+        if (seenPackages.isEmpty()) {
+            binding.appListEmpty.visibility = View.VISIBLE
+            binding.appList.visibility = View.GONE
+            return
+        }
+
+        binding.appListEmpty.visibility = View.GONE
+        binding.appList.visibility = View.VISIBLE
+
+        val pm = packageManager
+        val items = seenPackages.map { pkg ->
+            val appInfo = try {
+                pm.getApplicationInfo(pkg, 0)
+            } catch (e: PackageManager.NameNotFoundException) {
+                null
+            }
+            AppItem(
+                packageName = pkg,
+                label = appInfo?.let { pm.getApplicationLabel(it).toString() } ?: pkg,
+                icon = appInfo?.let { pm.getApplicationIcon(it) },
+                enabled = appPrefs.isAppEnabled(pkg)
+            )
+        }
+        appListAdapter.submitList(items)
     }
 
     private fun populateExplanations(explanations: List<PermissionExplanation>) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -203,6 +203,30 @@
                 android:textSize="14sp"
                 android:layout_marginBottom="32dp" />
 
+            <!-- Per-app debouncing -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Per-app debouncing"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:id="@+id/app_list_empty"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="No apps seen yet. Apps will appear here after they send notifications."
+                android:textSize="13sp"
+                android:visibility="gone"
+                android:layout_marginBottom="16dp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/app_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false" />
+
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/item_app_toggle.xml
+++ b/app/src/main/res/layout/item_app_toggle.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingVertical="8dp">
+
+    <ImageView
+        android:id="@+id/app_icon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginEnd="12dp"
+        android:contentDescription="App icon" />
+
+    <TextView
+        android:id="@+id/app_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textSize="14sp"
+        android:ellipsize="end"
+        android:maxLines="1" />
+
+    <com.google.android.material.materialswitch.MaterialSwitch
+        android:id="@+id/app_toggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/test/java/com/vibedebounce/prefs/AppPrefsTest.kt
+++ b/app/src/test/java/com/vibedebounce/prefs/AppPrefsTest.kt
@@ -1,0 +1,87 @@
+package com.vibedebounce.prefs
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AppPrefsTest {
+
+    private lateinit var context: Context
+    private lateinit var appPrefs: AppPrefs
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        appPrefs = AppPrefs(context)
+    }
+
+    @Test
+    fun `getSeenPackages returns empty set initially`() {
+        assertEquals(emptySet<String>(), appPrefs.getSeenPackages())
+    }
+
+    @Test
+    fun `addSeenPackage adds a package`() {
+        appPrefs.addSeenPackage("com.example.app")
+        assertTrue(appPrefs.getSeenPackages().contains("com.example.app"))
+    }
+
+    @Test
+    fun `addSeenPackage is idempotent`() {
+        appPrefs.addSeenPackage("com.example.app")
+        appPrefs.addSeenPackage("com.example.app")
+        assertEquals(1, appPrefs.getSeenPackages().size)
+    }
+
+    @Test
+    fun `addSeenPackage accumulates multiple packages`() {
+        appPrefs.addSeenPackage("com.example.one")
+        appPrefs.addSeenPackage("com.example.two")
+        appPrefs.addSeenPackage("com.example.three")
+        assertEquals(3, appPrefs.getSeenPackages().size)
+        assertTrue(appPrefs.getSeenPackages().containsAll(
+            setOf("com.example.one", "com.example.two", "com.example.three")
+        ))
+    }
+
+    @Test
+    fun `isAppEnabled defaults to true`() {
+        assertTrue(appPrefs.isAppEnabled("com.example.app"))
+    }
+
+    @Test
+    fun `setAppEnabled false disables app`() {
+        appPrefs.setAppEnabled("com.example.app", false)
+        assertFalse(appPrefs.isAppEnabled("com.example.app"))
+    }
+
+    @Test
+    fun `setAppEnabled true re-enables app`() {
+        appPrefs.setAppEnabled("com.example.app", false)
+        appPrefs.setAppEnabled("com.example.app", true)
+        assertTrue(appPrefs.isAppEnabled("com.example.app"))
+    }
+
+    @Test
+    fun `per-app state is independent`() {
+        appPrefs.setAppEnabled("com.example.one", false)
+        appPrefs.setAppEnabled("com.example.two", true)
+        assertFalse(appPrefs.isAppEnabled("com.example.one"))
+        assertTrue(appPrefs.isAppEnabled("com.example.two"))
+    }
+
+    @Test
+    fun `data persists across instances`() {
+        appPrefs.addSeenPackage("com.example.app")
+        appPrefs.setAppEnabled("com.example.app", false)
+
+        val appPrefs2 = AppPrefs(context)
+        assertTrue(appPrefs2.getSeenPackages().contains("com.example.app"))
+        assertFalse(appPrefs2.isAppEnabled("com.example.app"))
+    }
+}

--- a/app/src/test/java/com/vibedebounce/service/DebounceNotificationServiceAppFilterTest.kt
+++ b/app/src/test/java/com/vibedebounce/service/DebounceNotificationServiceAppFilterTest.kt
@@ -1,0 +1,59 @@
+package com.vibedebounce.service
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.vibedebounce.prefs.AppPrefs
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DebounceNotificationServiceAppFilterTest {
+
+    private lateinit var context: Context
+    private lateinit var service: DebounceNotificationService
+    private lateinit var appPrefs: AppPrefs
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        appPrefs = AppPrefs(context)
+        val controller = Robolectric.buildService(DebounceNotificationService::class.java)
+        service = controller.create().get()
+    }
+
+    @Test
+    fun `recordSeenApp adds package to AppPrefs`() {
+        service.recordSeenApp("com.example.chat")
+        assertTrue(appPrefs.getSeenPackages().contains("com.example.chat"))
+    }
+
+    @Test
+    fun `recordSeenApp is idempotent`() {
+        service.recordSeenApp("com.example.chat")
+        service.recordSeenApp("com.example.chat")
+        assertEquals(1, appPrefs.getSeenPackages().size)
+    }
+
+    @Test
+    fun `shouldDebounce returns true when app is enabled`() {
+        assertTrue(service.shouldDebounce("com.example.chat"))
+    }
+
+    @Test
+    fun `shouldDebounce returns false when app is disabled`() {
+        appPrefs.setAppEnabled("com.example.chat", false)
+        assertTrue(!service.shouldDebounce("com.example.chat"))
+    }
+
+    @Test
+    fun `shouldDebounce reflects changed state`() {
+        appPrefs.setAppEnabled("com.example.chat", false)
+        assertFalse(service.shouldDebounce("com.example.chat"))
+        appPrefs.setAppEnabled("com.example.chat", true)
+        assertTrue(service.shouldDebounce("com.example.chat"))
+    }
+}

--- a/app/src/test/java/com/vibedebounce/service/DebounceNotificationServiceAppFilterTest.kt
+++ b/app/src/test/java/com/vibedebounce/service/DebounceNotificationServiceAppFilterTest.kt
@@ -46,7 +46,7 @@ class DebounceNotificationServiceAppFilterTest {
     @Test
     fun `shouldDebounce returns false when app is disabled`() {
         appPrefs.setAppEnabled("com.example.chat", false)
-        assertTrue(!service.shouldDebounce("com.example.chat"))
+        assertFalse(service.shouldDebounce("com.example.chat"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `AppPrefs` SharedPreferences wrapper to persist seen packages and per-app enabled state
- Integrate into `DebounceNotificationService` to record seen apps on notification and skip debouncing for disabled apps
- Add per-app toggle UI in `MainActivity` with RecyclerView showing app icon, label, and MaterialSwitch

## Test plan
- [x] `AppPrefsTest` covers: empty initial state, add/idempotent/accumulate seen packages, default enabled, set enabled false/true, independent per-app state, persistence across instances (9 tests)
- [x] `DebounceNotificationServiceAppFilterTest` covers: recordSeenApp adds to prefs, idempotency, shouldDebounce true by default, false when disabled, reflects changed state (5 tests)
- [x] `./gradlew test assembleDebug` passes (BUILD SUCCESSFUL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)