### PR TITLE
FEAT-007: Inline permission explanations with checkmarks

### DIFF
--- a/app/src/main/java/com/vibedebounce/ui/MainActivity.kt
+++ b/app/src/main/java/com/vibedebounce/ui/MainActivity.kt
@@ -2,13 +2,10 @@ package com.vibedebounce.ui
 
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Typeface
 import android.os.Bundle
 import android.provider.Settings
 import android.view.View
-import android.widget.LinearLayout
 import android.widget.SeekBar
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.vibedebounce.databinding.ActivityMainBinding
@@ -92,17 +89,28 @@ class MainActivity : AppCompatActivity() {
         binding.settingsSection.visibility = if (showSettings) View.VISIBLE else View.GONE
         binding.permissionGuardCard.visibility = if (permissionGuard.shouldShowGuardCard()) View.VISIBLE else View.GONE
 
-        if (permissionGuard.shouldShowGuardCard()) {
-            populateExplanations(permissionGuard.missingPermissionExplanations())
-        }
-
         // Update individual permission statuses
         val notificationAccessGranted = permissionChecker.isNotificationListenerEnabled()
         val dndAccessGranted = permissionChecker.isDndAccessGranted()
         binding.statusNotificationAccess.text = if (notificationAccessGranted) "Granted" else "Not granted"
         binding.statusDndAccess.text = if (dndAccessGranted) "Granted" else "Not granted"
-        binding.btnNotificationAccess.isEnabled = !notificationAccessGranted
-        binding.btnDndAccess.isEnabled = !dndAccessGranted
+
+        // Update inline permission explanations
+        val states = permissionGuard.permissionRowStates()
+        for (state in states) {
+            when (state.permission) {
+                Permission.NOTIFICATION_LISTENER -> {
+                    binding.explanationNotificationAccess.visibility = if (state.granted) View.GONE else View.VISIBLE
+                    binding.checkmarkNotificationAccess.visibility = if (state.granted) View.VISIBLE else View.GONE
+                    binding.btnNotificationAccess.visibility = if (state.granted) View.GONE else View.VISIBLE
+                }
+                Permission.DND_ACCESS -> {
+                    binding.explanationDndAccess.visibility = if (state.granted) View.GONE else View.VISIBLE
+                    binding.checkmarkDndAccess.visibility = if (state.granted) View.VISIBLE else View.GONE
+                    binding.btnDndAccess.visibility = if (state.granted) View.GONE else View.VISIBLE
+                }
+            }
+        }
     }
 
     private fun setupAppList() {
@@ -139,35 +147,5 @@ class MainActivity : AppCompatActivity() {
             )
         }
         appListAdapter.submitList(items)
-    }
-
-    private fun populateExplanations(explanations: List<PermissionExplanation>) {
-        binding.permissionExplanationsContainer.removeAllViews()
-        for (explanation in explanations) {
-            val container = LinearLayout(this).apply {
-                orientation = LinearLayout.VERTICAL
-                val params = LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
-                )
-                params.bottomMargin = (12 * resources.displayMetrics.density).toInt()
-                layoutParams = params
-            }
-
-            val titleView = TextView(this).apply {
-                text = explanation.title
-                textSize = 14f
-                setTypeface(null, Typeface.BOLD)
-            }
-
-            val descView = TextView(this).apply {
-                text = explanation.explanation
-                textSize = 13f
-            }
-
-            container.addView(titleView)
-            container.addView(descView)
-            binding.permissionExplanationsContainer.addView(container)
-        }
     }
 }

--- a/app/src/main/java/com/vibedebounce/ui/PermissionGuard.kt
+++ b/app/src/main/java/com/vibedebounce/ui/PermissionGuard.kt
@@ -1,27 +1,11 @@
 package com.vibedebounce.ui
 
-data class PermissionExplanation(
+data class PermissionRowState(
     val permission: Permission,
-    val title: String,
-    val explanation: String
+    val granted: Boolean
 )
 
 class PermissionGuard(private val checker: PermissionCheckerContract) {
-
-    companion object {
-        private val EXPLANATIONS = mapOf(
-            Permission.NOTIFICATION_LISTENER to PermissionExplanation(
-                permission = Permission.NOTIFICATION_LISTENER,
-                title = "Notification Access",
-                explanation = "Lets Debounce see when notifications arrive so it can detect message bursts from the same sender. Your message content is never read or stored."
-            ),
-            Permission.DND_ACCESS to PermissionExplanation(
-                permission = Permission.DND_ACCESS,
-                title = "Do Not Disturb Access",
-                explanation = "Lets Debounce briefly silence your phone when repeat messages arrive, then restore your previous sound setting automatically."
-            )
-        )
-    }
 
     fun isGuardActive(): Boolean = !checker.allPermissionsGranted()
 
@@ -29,6 +13,10 @@ class PermissionGuard(private val checker: PermissionCheckerContract) {
 
     fun shouldShowGuardCard(): Boolean = isGuardActive()
 
-    fun missingPermissionExplanations(): List<PermissionExplanation> =
-        checker.missingPermissions().mapNotNull { EXPLANATIONS[it] }
+    fun permissionRowStates(): List<PermissionRowState> {
+        val missing = checker.missingPermissions().toSet()
+        return listOf(Permission.NOTIFICATION_LISTENER, Permission.DND_ACCESS).map { perm ->
+            PermissionRowState(permission = perm, granted = perm !in missing)
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -56,82 +56,122 @@
                     android:textSize="14sp"
                     android:layout_marginBottom="16dp" />
 
-                <LinearLayout
-                    android:id="@+id/permission_explanations_container"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:layout_marginBottom="16dp" />
-
                 <!-- Notification Access -->
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical"
+                    android:orientation="vertical"
                     android:layout_marginBottom="12dp">
 
                     <LinearLayout
-                        android:layout_width="0dp"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
 
-                        <TextView
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Notification access"
+                                android:textSize="14sp" />
+
+                            <TextView
+                                android:id="@+id/status_notification_access"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Not granted"
+                                android:textSize="12sp" />
+                        </LinearLayout>
+
+                        <ImageView
+                            android:id="@+id/checkmark_notification_access"
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:src="@android:drawable/checkbox_on_background"
+                            android:contentDescription="Granted"
+                            android:visibility="gone" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btn_notification_access"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Notification access"
-                            android:textSize="14sp" />
-
-                        <TextView
-                            android:id="@+id/status_notification_access"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Not granted"
-                            android:textSize="12sp" />
+                            android:text="Grant"
+                            style="@style/Widget.Material3.Button.OutlinedButton" />
                     </LinearLayout>
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btn_notification_access"
+                    <TextView
+                        android:id="@+id/explanation_notification_access"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Grant"
-                        style="@style/Widget.Material3.Button.OutlinedButton" />
+                        android:text="@string/notification_listener_explanation"
+                        android:textSize="12sp"
+                        android:layout_marginTop="4dp"
+                        android:visibility="visible" />
                 </LinearLayout>
 
                 <!-- DND Access -->
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical">
+                    android:orientation="vertical"
+                    android:layout_marginBottom="12dp">
 
                     <LinearLayout
-                        android:layout_width="0dp"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
 
-                        <TextView
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Do Not Disturb access"
+                                android:textSize="14sp" />
+
+                            <TextView
+                                android:id="@+id/status_dnd_access"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Not granted"
+                                android:textSize="12sp" />
+                        </LinearLayout>
+
+                        <ImageView
+                            android:id="@+id/checkmark_dnd_access"
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:src="@android:drawable/checkbox_on_background"
+                            android:contentDescription="Granted"
+                            android:visibility="gone" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btn_dnd_access"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Do Not Disturb access"
-                            android:textSize="14sp" />
-
-                        <TextView
-                            android:id="@+id/status_dnd_access"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="Not granted"
-                            android:textSize="12sp" />
+                            android:text="Grant"
+                            style="@style/Widget.Material3.Button.OutlinedButton" />
                     </LinearLayout>
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btn_dnd_access"
+                    <TextView
+                        android:id="@+id/explanation_dnd_access"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Grant"
-                        style="@style/Widget.Material3.Button.OutlinedButton" />
+                        android:text="@string/dnd_access_explanation"
+                        android:textSize="12sp"
+                        android:layout_marginTop="4dp"
+                        android:visibility="visible" />
                 </LinearLayout>
 
             </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -89,12 +89,14 @@
                                 android:textSize="12sp" />
                         </LinearLayout>
 
-                        <ImageView
+                        <TextView
                             android:id="@+id/checkmark_notification_access"
                             android:layout_width="24dp"
                             android:layout_height="24dp"
-                            android:src="@android:drawable/checkbox_on_background"
-                            android:contentDescription="Granted"
+                            android:text="\u2713"
+                            android:textSize="18sp"
+                            android:textColor="@android:color/holo_green_dark"
+                            android:gravity="center"
                             android:visibility="gone" />
 
                         <com.google.android.material.button.MaterialButton
@@ -148,12 +150,14 @@
                                 android:textSize="12sp" />
                         </LinearLayout>
 
-                        <ImageView
+                        <TextView
                             android:id="@+id/checkmark_dnd_access"
                             android:layout_width="24dp"
                             android:layout_height="24dp"
-                            android:src="@android:drawable/checkbox_on_background"
-                            android:contentDescription="Granted"
+                            android:text="\u2713"
+                            android:textSize="18sp"
+                            android:textColor="@android:color/holo_green_dark"
+                            android:gravity="center"
                             android:visibility="gone" />
 
                         <com.google.android.material.button.MaterialButton

--- a/app/src/test/java/com/vibedebounce/ui/PermissionGuardTest.kt
+++ b/app/src/test/java/com/vibedebounce/ui/PermissionGuardTest.kt
@@ -42,17 +42,50 @@ class PermissionGuardTest {
     }
 
     @Test
-    fun `explanation text includes notification listener when missing`() {
+    fun `permissionRowStates returns not-granted for missing notification listener`() {
         val guard = PermissionGuard(FakePermissionChecker(notificationListener = false, dndAccess = true))
-        val explanations = guard.missingPermissionExplanations()
-        assertEquals(1, explanations.size)
-        assertEquals(Permission.NOTIFICATION_LISTENER, explanations[0].permission)
+        val states = guard.permissionRowStates()
+        val nl = states.first { it.permission == Permission.NOTIFICATION_LISTENER }
+        assertFalse(nl.granted)
     }
 
     @Test
-    fun `explanation text includes both when both missing`() {
+    fun `permissionRowStates returns granted for granted notification listener`() {
+        val guard = PermissionGuard(FakePermissionChecker(notificationListener = true, dndAccess = true))
+        val states = guard.permissionRowStates()
+        val nl = states.first { it.permission == Permission.NOTIFICATION_LISTENER }
+        assertTrue(nl.granted)
+    }
+
+    @Test
+    fun `permissionRowStates returns not-granted for missing dnd access`() {
+        val guard = PermissionGuard(FakePermissionChecker(notificationListener = true, dndAccess = false))
+        val states = guard.permissionRowStates()
+        val dnd = states.first { it.permission == Permission.DND_ACCESS }
+        assertFalse(dnd.granted)
+    }
+
+    @Test
+    fun `permissionRowStates returns granted for granted dnd access`() {
+        val guard = PermissionGuard(FakePermissionChecker(notificationListener = true, dndAccess = true))
+        val states = guard.permissionRowStates()
+        val dnd = states.first { it.permission == Permission.DND_ACCESS }
+        assertTrue(dnd.granted)
+    }
+
+    @Test
+    fun `permissionRowStates always returns both permissions`() {
         val guard = PermissionGuard(FakePermissionChecker(notificationListener = false, dndAccess = false))
-        val explanations = guard.missingPermissionExplanations()
-        assertEquals(2, explanations.size)
+        val states = guard.permissionRowStates()
+        assertEquals(2, states.size)
+        assertTrue(states.any { it.permission == Permission.NOTIFICATION_LISTENER })
+        assertTrue(states.any { it.permission == Permission.DND_ACCESS })
+    }
+
+    @Test
+    fun `permissionRowStates all granted when all permissions granted`() {
+        val guard = PermissionGuard(FakePermissionChecker(notificationListener = true, dndAccess = true))
+        val states = guard.permissionRowStates()
+        assertTrue(states.all { it.granted })
     }
 }


### PR DESCRIPTION
## Summary
- Replace separate explanation container with inline explanations per permission row
- Show explanation text before granting, replace with checkmark after granting
- Add `PermissionRowState` to `PermissionGuard` for per-permission granted state
- Remove deprecated `PermissionExplanation` and `missingPermissionExplanations()`

## Test plan
- [ ] 6 new unit tests for `permissionRowStates()` cover all grant/deny combos
- [ ] 6 existing PermissionGuard tests still pass
- [ ] Manual: verify explanations visible before granting, checkmark after

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)