### PR TITLE
fix(BUG-002): guard onNotificationPosted against own-package notifications

### DIFF
--- a/app/src/main/java/com/vibedebounce/service/DebounceNotificationService.kt
+++ b/app/src/main/java/com/vibedebounce/service/DebounceNotificationService.kt
@@ -79,6 +79,8 @@ class DebounceNotificationService : NotificationListenerService() {
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification) {
+        if (sbn.packageName == packageName) return
+
         recordSeenApp(sbn.packageName)
         if (!shouldDebounce(sbn.packageName)) return
 

--- a/app/src/test/java/com/vibedebounce/service/DebounceNotificationServiceAppFilterTest.kt
+++ b/app/src/test/java/com/vibedebounce/service/DebounceNotificationServiceAppFilterTest.kt
@@ -1,12 +1,17 @@
 package com.vibedebounce.service
 
+import android.app.Notification
 import android.content.Context
+import android.os.Bundle
+import android.service.notification.StatusBarNotification
 import androidx.test.core.app.ApplicationProvider
 import com.vibedebounce.prefs.AppPrefs
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when` as whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
@@ -23,6 +28,20 @@ class DebounceNotificationServiceAppFilterTest {
         appPrefs = AppPrefs(context)
         val controller = Robolectric.buildService(DebounceNotificationService::class.java)
         service = controller.create().get()
+        DebounceNotificationService.resetState()
+    }
+
+    private fun createMockSbn(packageName: String, title: String): StatusBarNotification {
+        val extras = Bundle().apply {
+            putString(Notification.EXTRA_TITLE, title)
+        }
+        val notification = mock(Notification::class.java).apply {
+            this.extras = extras
+        }
+        val sbn = mock(StatusBarNotification::class.java)
+        whenever(sbn.packageName).thenReturn(packageName)
+        whenever(sbn.notification).thenReturn(notification)
+        return sbn
     }
 
     @Test
@@ -55,5 +74,26 @@ class DebounceNotificationServiceAppFilterTest {
         assertFalse(service.shouldDebounce("com.example.chat"))
         appPrefs.setAppEnabled("com.example.chat", true)
         assertTrue(service.shouldDebounce("com.example.chat"))
+    }
+
+    @Test
+    fun `onNotificationPosted ignores notifications from own package`() {
+        val sbn = createMockSbn("com.vibedebounce", "Test sender")
+        service.onNotificationPosted(sbn)
+        assertFalse(appPrefs.getSeenPackages().contains("com.vibedebounce"))
+    }
+
+    @Test
+    fun `onNotificationPosted still processes notifications from other packages`() {
+        val sbn = createMockSbn("com.example.chat", "Alice")
+        service.onNotificationPosted(sbn)
+        assertTrue(appPrefs.getSeenPackages().contains("com.example.chat"))
+    }
+
+    @Test
+    fun `own package notification does not create debounce timer`() {
+        val sbn = createMockSbn("com.vibedebounce", "New conversation")
+        service.onNotificationPosted(sbn)
+        assertEquals(0, DebounceNotificationService.activeWindowCount)
     }
 }


### PR DESCRIPTION
## Summary

- Adds an early-return guard as the very first line of `onNotificationPosted()` when `sbn.packageName == packageName`, preventing the service from processing its own foreground/alert notifications
- Guard runs before `recordSeenApp()` so `com.vibedebounce` never appears in the seen-apps list
- Adds three new unit tests to `DebounceNotificationServiceAppFilterTest` covering the self-filter behaviour

## Test plan

- [x] `./gradlew test` -- 74 tests pass (3 new tests added)
- [x] `./gradlew assembleDebug` -- clean build
- [ ] Manual: trigger a notification from an external app and confirm debounce still fires
- [ ] Manual: confirm the service's own status-bar notification does not appear in the seen-apps toggle list

Fixes BUG-002.

Generated with Claude Code
