### PR TITLE
fix(BUG-001): restore ringer on service disconnect and destroy

### DIFF
--- a/app/src/main/java/com/vibedebounce/service/DebounceNotificationService.kt
+++ b/app/src/main/java/com/vibedebounce/service/DebounceNotificationService.kt
@@ -39,8 +39,15 @@ class DebounceNotificationService : NotificationListenerService() {
     private lateinit var appPrefs: AppPrefs
     private lateinit var foregroundNotificationManager: ForegroundNotificationManager
     private val activeTimers = mutableMapOf<SenderKey, DebounceTimer>()
+
     @VisibleForTesting
     internal var debounceWindowMs = DEFAULT_DEBOUNCE_MS
+
+    @VisibleForTesting
+    internal val activeTimerCount: Int get() = activeTimers.size
+
+    @VisibleForTesting
+    internal fun getRingerStateManagerForTest(): RingerStateManager = ringerStateManager
 
     private val prefsListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
         if (key == DebouncePrefs.KEY_DEBOUNCE_SECONDS) {
@@ -73,8 +80,8 @@ class DebounceNotificationService : NotificationListenerService() {
     }
 
     override fun onListenerDisconnected() {
+        clearAllTimersAndRestore()
         isRunning = false
-        activeWindowCount = 0
         stopForeground(STOP_FOREGROUND_REMOVE)
     }
 
@@ -123,6 +130,15 @@ class DebounceNotificationService : NotificationListenerService() {
         )
     }
 
+    private fun clearAllTimersAndRestore() {
+        activeTimers.values.forEach { it.cancel() }
+        activeTimers.clear()
+        activeWindowCount = 0
+        if (::ringerStateManager.isInitialized) {
+            ringerStateManager.releaseAll()
+        }
+    }
+
     @VisibleForTesting
     internal fun recordSeenApp(packageName: String) {
         appPrefs.addSeenPackage(packageName)
@@ -134,6 +150,7 @@ class DebounceNotificationService : NotificationListenerService() {
     }
 
     override fun onDestroy() {
+        clearAllTimersAndRestore()
         debouncePrefs.unregisterOnChangeListener(prefsListener)
         super.onDestroy()
     }

--- a/app/src/main/java/com/vibedebounce/service/RingerStateManager.kt
+++ b/app/src/main/java/com/vibedebounce/service/RingerStateManager.kt
@@ -26,6 +26,15 @@ class RingerStateManager(private val audioManager: AudioManager) {
     }
 
     @Synchronized
+    fun releaseAll() {
+        if (activeDebounceCount > 0) {
+            activeDebounceCount = 0
+            savedRingerMode?.let { audioManager.ringerMode = it }
+            savedRingerMode = null
+        }
+    }
+
+    @Synchronized
     fun isActive(): Boolean = activeDebounceCount > 0
 
     @Synchronized

--- a/app/src/test/java/com/vibedebounce/DebounceNotificationServiceTest.kt
+++ b/app/src/test/java/com/vibedebounce/DebounceNotificationServiceTest.kt
@@ -55,4 +55,56 @@ class DebounceNotificationServiceTest {
         // Service is destroyed; debounceWindowMs should retain its last value (the default 90s).
         assertEquals(DebouncePrefs.DEFAULT_SECONDS * 1000L, service.debounceWindowMs)
     }
+
+    @Test
+    fun `onListenerDisconnected cancels all timers and restores ringer`() {
+        val controller = Robolectric.buildService(DebounceNotificationService::class.java)
+        val service = controller.create().get()
+        val rsm = service.getRingerStateManagerForTest()
+
+        // Simulate active debounce state: mute twice (as if 2 senders active)
+        rsm.mute()
+        rsm.mute()
+        assertTrue(rsm.isActive())
+
+        // Trigger disconnect
+        service.onListenerDisconnected()
+
+        // Ringer must be restored
+        assertFalse(rsm.isActive())
+        assertEquals(0, rsm.activeCount())
+
+        // Companion state must be reset
+        assertFalse(DebounceNotificationService.isRunning)
+        assertEquals(0, DebounceNotificationService.activeWindowCount)
+    }
+
+    @Test
+    fun `onDestroy cancels all timers and restores ringer`() {
+        val controller = Robolectric.buildService(DebounceNotificationService::class.java)
+        val service = controller.create().get()
+        val rsm = service.getRingerStateManagerForTest()
+
+        rsm.mute()
+        assertTrue(rsm.isActive())
+
+        controller.destroy()
+
+        assertFalse(rsm.isActive())
+        assertEquals(0, rsm.activeCount())
+    }
+
+    @Test
+    fun `clearAllTimersAndRestore is idempotent`() {
+        val controller = Robolectric.buildService(DebounceNotificationService::class.java)
+        val service = controller.create().get()
+
+        // Call disconnect then destroy -- both call clearAllTimersAndRestore
+        service.onListenerDisconnected()
+        controller.destroy()
+
+        // Should not throw, ringer state should be clean
+        val rsm = service.getRingerStateManagerForTest()
+        assertFalse(rsm.isActive())
+    }
 }

--- a/app/src/test/java/com/vibedebounce/RingerStateManagerTest.kt
+++ b/app/src/test/java/com/vibedebounce/RingerStateManagerTest.kt
@@ -53,7 +53,7 @@ class RingerStateManagerTest {
         whenever(audioManager.ringerMode).thenReturn(AudioManager.RINGER_MODE_SILENT)
         ringerStateManager.mute()
         ringerStateManager.release()
-        // mute sets SILENT, release restores SILENT — both set the same value
+        // mute sets SILENT, release restores SILENT -- both set the same value
         verify(audioManager, org.mockito.Mockito.times(2)).ringerMode = AudioManager.RINGER_MODE_SILENT
     }
 
@@ -63,5 +63,39 @@ class RingerStateManagerTest {
         ringerStateManager.mute()
         // Verify only SILENT was set, never NORMAL
         verify(audioManager, never()).ringerMode = AudioManager.RINGER_MODE_NORMAL
+    }
+
+    @Test
+    fun `releaseAll restores ringer when multiple mutes are active`() {
+        whenever(audioManager.ringerMode).thenReturn(AudioManager.RINGER_MODE_NORMAL)
+        ringerStateManager.mute()
+        ringerStateManager.mute()
+        ringerStateManager.mute()
+        assertEquals(3, ringerStateManager.activeCount())
+
+        ringerStateManager.releaseAll()
+
+        assertFalse(ringerStateManager.isActive())
+        assertEquals(0, ringerStateManager.activeCount())
+        verify(audioManager).ringerMode = AudioManager.RINGER_MODE_NORMAL
+    }
+
+    @Test
+    fun `releaseAll is safe when no mutes are active`() {
+        ringerStateManager.releaseAll()
+        assertFalse(ringerStateManager.isActive())
+        // No exception, no ringer mode change
+        verify(audioManager, never()).ringerMode = AudioManager.RINGER_MODE_NORMAL
+    }
+
+    @Test
+    fun `releaseAll restores original mode not silent`() {
+        whenever(audioManager.ringerMode).thenReturn(AudioManager.RINGER_MODE_VIBRATE)
+        ringerStateManager.mute()
+        ringerStateManager.mute()
+
+        ringerStateManager.releaseAll()
+
+        verify(audioManager).ringerMode = AudioManager.RINGER_MODE_VIBRATE
     }
 }


### PR DESCRIPTION
## Summary

- Add `RingerStateManager.releaseAll()` to atomically drop the refcount and restore the saved ringer mode in one synchronized call, without requiring N separate `release()` calls
- Add `DebounceNotificationService.clearAllTimersAndRestore()` which cancels all active timers, clears the timer map, resets `activeWindowCount`, and calls `releaseAll()`
- Wire `clearAllTimersAndRestore()` into `onListenerDisconnected()` and `onDestroy()` so the phone is never left muted when the service exits

## Test plan

- [ ] `RingerStateManagerTest`: 3 new tests covering `releaseAll()` with multiple active mutes, no active mutes (safe no-op), and restoring non-normal modes (vibrate)
- [ ] `DebounceNotificationServiceTest`: 3 new tests covering `onListenerDisconnected` restores ringer and resets companion state, `onDestroy` restores ringer, and `clearAllTimersAndRestore` being idempotent when called twice
- [ ] All 6 new tests pass alongside the full existing test suite (59 tasks, BUILD SUCCESSFUL)
- [ ] `assembleDebug` succeeds with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
