### PR TITLE
fix: vibrate before mute so first notification is felt

### DIFF
--- a/app/src/main/java/com/vibedebounce/service/DebounceNotificationService.kt
+++ b/app/src/main/java/com/vibedebounce/service/DebounceNotificationService.kt
@@ -101,8 +101,13 @@ class DebounceNotificationService : NotificationListenerService() {
             return
         }
 
+        // Always vibrate for the first notification from a new sender.
+        // If another debounce window is already active, also post the new-thread notification.
+        // fire() calls vibrate() internally, so call one or the other -- not both.
         if (ringerStateManager.isActive()) {
             notifier.fire(title)
+        } else {
+            notifier.vibrate()
         }
 
         ringerStateManager.mute()
@@ -139,6 +144,11 @@ class DebounceNotificationService : NotificationListenerService() {
         if (::ringerStateManager.isInitialized) {
             ringerStateManager.releaseAll()
         }
+    }
+
+    @VisibleForTesting
+    internal fun setNotifierForTest(notifier: NewThreadNotifier) {
+        this.notifier = notifier
     }
 
     @VisibleForTesting

--- a/app/src/main/java/com/vibedebounce/service/NewThreadNotifier.kt
+++ b/app/src/main/java/com/vibedebounce/service/NewThreadNotifier.kt
@@ -9,7 +9,7 @@ import androidx.core.app.NotificationCompat
 import com.vibedebounce.R
 
 /**
- * Fires a vibration and posts a notification for a new conversation thread.
+ * Fires a vibration and optionally posts a notification for a new conversation thread.
  * Uses the Vibrator API directly -- does NOT touch ringer mode.
  * This is safe to call regardless of the current ringer state because
  * Vibrator.vibrate() works in silent mode when the app holds VIBRATE permission.
@@ -36,17 +36,26 @@ class NewThreadNotifier(
     }
 
     /**
-     * Vibrates and posts a notification for a new conversation thread.
-     * Uses Vibrator API directly -- does NOT touch ringer mode.
+     * Fires a vibration using the Vibrator API directly.
+     * Does NOT post a notification. Does NOT touch ringer mode.
      * Safe to call regardless of current ringer state.
      */
-    fun fire(senderName: String) {
+    fun vibrate() {
         vibrator.vibrate(
             VibrationEffect.createOneShot(
                 VIBRATION_DURATION_MS,
                 VibrationEffect.DEFAULT_AMPLITUDE
             )
         )
+    }
+
+    /**
+     * Vibrates and posts a notification for a new conversation thread.
+     * Uses Vibrator API directly -- does NOT touch ringer mode.
+     * Safe to call regardless of current ringer state.
+     */
+    fun fire(senderName: String) {
+        vibrate()
 
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)

--- a/app/src/test/java/com/vibedebounce/DebounceNotificationServiceTest.kt
+++ b/app/src/test/java/com/vibedebounce/DebounceNotificationServiceTest.kt
@@ -1,13 +1,16 @@
 package com.vibedebounce
 
 import android.content.Context
+import android.service.notification.StatusBarNotification
 import androidx.test.core.app.ApplicationProvider
 import com.vibedebounce.prefs.DebouncePrefs
 import com.vibedebounce.service.DebounceNotificationService
+import com.vibedebounce.service.NewThreadNotifier
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.*
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
@@ -25,14 +28,9 @@ class DebounceNotificationServiceTest {
 
     @Test
     fun `onPreferenceChanged updates debounceWindowMs from SharedPreferences`() {
-        // Arrange: create service, manually invoke onCreate
         val controller = Robolectric.buildService(DebounceNotificationService::class.java)
         val service = controller.create().get()
-
-        // Act: change the pref (simulating user moving slider)
         prefs.debounceWindowSeconds = 45
-
-        // Assert: service picked up the new value
         assertEquals(45_000L, service.debounceWindowMs)
     }
 
@@ -49,10 +47,7 @@ class DebounceNotificationServiceTest {
         val controller = Robolectric.buildService(DebounceNotificationService::class.java)
         val service = controller.create().get()
         controller.destroy()
-
-        // After destroy, changing prefs should NOT update the service's field.
         prefs.debounceWindowSeconds = 15
-        // Service is destroyed; debounceWindowMs should retain its last value (the default 90s).
         assertEquals(DebouncePrefs.DEFAULT_SECONDS * 1000L, service.debounceWindowMs)
     }
 
@@ -62,19 +57,14 @@ class DebounceNotificationServiceTest {
         val service = controller.create().get()
         val rsm = service.getRingerStateManagerForTest()
 
-        // Simulate active debounce state: mute twice (as if 2 senders active)
         rsm.mute()
         rsm.mute()
         assertTrue(rsm.isActive())
 
-        // Trigger disconnect
         service.onListenerDisconnected()
 
-        // Ringer must be restored
         assertFalse(rsm.isActive())
         assertEquals(0, rsm.activeCount())
-
-        // Companion state must be reset
         assertFalse(DebounceNotificationService.isRunning)
         assertEquals(0, DebounceNotificationService.activeWindowCount)
     }
@@ -99,12 +89,92 @@ class DebounceNotificationServiceTest {
         val controller = Robolectric.buildService(DebounceNotificationService::class.java)
         val service = controller.create().get()
 
-        // Call disconnect then destroy -- both call clearAllTimersAndRestore
         service.onListenerDisconnected()
         controller.destroy()
 
-        // Should not throw, ringer state should be clean
         val rsm = service.getRingerStateManagerForTest()
         assertFalse(rsm.isActive())
+    }
+
+    @Test
+    fun `first notification from new sender vibrates before muting`() {
+        val controller = Robolectric.buildService(DebounceNotificationService::class.java)
+        val service = controller.create().get()
+
+        val mockNotifier: NewThreadNotifier = mock()
+        service.setNotifierForTest(mockNotifier)
+
+        val sbn = buildMockSbn("com.example.chat", "Alice")
+        service.onNotificationPosted(sbn)
+
+        verify(mockNotifier).vibrate()
+    }
+
+    @Test
+    fun `first notification from new sender does not post new-thread notification when no other debounce active`() {
+        val controller = Robolectric.buildService(DebounceNotificationService::class.java)
+        val service = controller.create().get()
+
+        val mockNotifier: NewThreadNotifier = mock()
+        service.setNotifierForTest(mockNotifier)
+
+        val sbn = buildMockSbn("com.example.chat", "Alice")
+        service.onNotificationPosted(sbn)
+
+        verify(mockNotifier).vibrate()
+        verify(mockNotifier, never()).fire(any())
+    }
+
+    @Test
+    fun `new sender during active debounce fires full notification`() {
+        val controller = Robolectric.buildService(DebounceNotificationService::class.java)
+        val service = controller.create().get()
+
+        val mockNotifier: NewThreadNotifier = mock()
+        service.setNotifierForTest(mockNotifier)
+
+        val sbn1 = buildMockSbn("com.example.chat", "Alice")
+        service.onNotificationPosted(sbn1)
+
+        reset(mockNotifier)
+
+        val sbn2 = buildMockSbn("com.example.chat", "Bob")
+        service.onNotificationPosted(sbn2)
+
+        // fire() handles vibration internally; mock won't delegate
+        verify(mockNotifier, never()).vibrate()
+        verify(mockNotifier).fire("Bob")
+    }
+
+    @Test
+    fun `repeat notification from same sender during debounce does not vibrate`() {
+        val controller = Robolectric.buildService(DebounceNotificationService::class.java)
+        val service = controller.create().get()
+
+        val mockNotifier: NewThreadNotifier = mock()
+        service.setNotifierForTest(mockNotifier)
+
+        val sbn = buildMockSbn("com.example.chat", "Alice")
+        service.onNotificationPosted(sbn)
+
+        reset(mockNotifier)
+
+        service.onNotificationPosted(sbn)
+
+        verify(mockNotifier, never()).vibrate()
+        verify(mockNotifier, never()).fire(any())
+    }
+
+    private fun buildMockSbn(packageName: String, title: String): StatusBarNotification {
+        val extras = android.os.Bundle().apply {
+            putString(android.app.Notification.EXTRA_TITLE, title)
+        }
+        val notification = android.app.Notification().apply {
+            this.extras = extras
+        }
+        val sbn: StatusBarNotification = mock()
+        whenever(sbn.packageName).thenReturn(packageName)
+        whenever(sbn.notification).thenReturn(notification)
+        return sbn
     }
 }

--- a/app/src/test/java/com/vibedebounce/service/NewThreadNotifierTest.kt
+++ b/app/src/test/java/com/vibedebounce/service/NewThreadNotifierTest.kt
@@ -58,7 +58,7 @@ class NewThreadNotifierTest {
         notifier.vibrate()
 
         verify(vibrator).vibrate(any<VibrationEffect>())
-        verify(notificationManager, never()).notify(anyInt(), any())
+        verify(notificationManager, never()).notify(any(), any())
     }
 
     @Test

--- a/app/src/test/java/com/vibedebounce/service/NewThreadNotifierTest.kt
+++ b/app/src/test/java/com/vibedebounce/service/NewThreadNotifierTest.kt
@@ -52,4 +52,32 @@ class NewThreadNotifierTest {
         // has no AudioManager dependency. If this compiles, the invariant holds.
         notifier.fire("Charlie")
     }
+
+    @Test
+    fun `vibrate fires a one-shot vibration without posting a notification`() {
+        notifier.vibrate()
+
+        verify(vibrator).vibrate(any<VibrationEffect>())
+        verify(notificationManager, never()).notify(anyInt(), any())
+    }
+
+    @Test
+    fun `vibrate uses same duration as fire`() {
+        notifier.vibrate()
+
+        val expectedEffect = VibrationEffect.createOneShot(
+            NewThreadNotifier.VIBRATION_DURATION_MS,
+            VibrationEffect.DEFAULT_AMPLITUDE
+        )
+        verify(vibrator).vibrate(eq(expectedEffect))
+    }
+
+    @Test
+    fun `fire still vibrates and posts notification after extracting vibrate`() {
+        // Regression: ensure fire() behavior is unchanged
+        notifier.fire("Alice")
+
+        verify(vibrator).vibrate(any<VibrationEffect>())
+        verify(notificationManager).notify(eq("Alice".hashCode()), any())
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes BUG-003: first notification from a new sender was silenced before the system could vibrate it
- Extracts `vibrate()` method from `fire()` in `NewThreadNotifier` so the service can vibrate without posting the "new conversation" notification
- Updates `onNotificationPosted` to always vibrate for a new sender, using an if/else to call `fire()` (vibrate + notification) when another debounce window is already active or `vibrate()` alone when this is the first active window -- preventing double-vibration while fixing the core bug

## Test plan

- [ ] `NewThreadNotifierTest`: 3 new tests for `vibrate()` (vibrates without notification, correct duration, `fire()` regression)
- [ ] `DebounceNotificationServiceTest`: 4 new tests (first sender vibrates, first sender does not post new-thread notification, second concurrent sender fires full notification, repeat same-sender does not vibrate)
- [ ] Run `./gradlew test` -- all existing tests plus new tests pass
- [ ] Run `./gradlew assembleDebug` -- APK builds cleanly
- [ ] Manual smoke test: send first message from a new contact and confirm vibration is felt

Closes BUG-003

Generated with [Claude Code](https://claude.com/claude-code)

-Claude Dev
